### PR TITLE
fix: Harden Payment Gateway Webhook for Top Up Credit

### DIFF
--- a/src/modules/payment/midtrans/midtrans.config.ts
+++ b/src/modules/payment/midtrans/midtrans.config.ts
@@ -1,7 +1,7 @@
 import { MidtransClientOptions } from 'midtrans-client';
 
 export const midtransConfig: MidtransClientOptions = {
-  isProduction: false,
+  isProduction: process.env.MIDTRANS_IS_PRODUCTION === 'true',
   serverKey: process.env.MIDTRANS_SERVER_KEY || '',
   clientKey: process.env.MIDTRANS_CLIENT_KEY || '',
 };

--- a/src/modules/payment/midtrans/midtrans.service.ts
+++ b/src/modules/payment/midtrans/midtrans.service.ts
@@ -1,14 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import midtransClient from 'midtrans-client';
 import { midtransConfig } from './midtrans.config';
 import crypto from 'crypto';
 import { MidtransSnapParams } from '../../../model/payment.model';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
 
 @Injectable()
 export class MidtransService {
   private snap: midtransClient.Snap;
 
-  constructor() {
+  constructor(
+    @Inject(WINSTON_MODULE_PROVIDER) private logger: Logger,
+  ) {
     this.snap = new midtransClient.Snap({
       isProduction: midtransConfig.isProduction,
       serverKey: midtransConfig.serverKey,
@@ -52,13 +56,21 @@ export class MidtransService {
         redirectUrl: transaction.redirect_url,
       };
     } catch (err) {
-      console.error('Midtrans error:', err);
+      this.logger.error('[Midtrans] createTransaction failed', {
+        orderId,
+        error: err instanceof Error ? err.message : String(err),
+      });
       throw new Error('Failed to create Midtrans transaction');
     }
   }
 
   /**
-   * (Opsional) verifikasi signature pada callback Midtrans
+   * [WAJIB] Verifikasi signature dari Midtrans webhook notification.
+   * Signature = SHA512(order_id + status_code + gross_amount + server_key)
+   * Ref: https://docs.midtrans.com/docs/https-notification-webhooks
+   *
+   * JANGAN lewati verifikasi ini — tanpa ini siapa pun bisa mengirim
+   * fake webhook dan menambah kredit secara ilegal.
    */
   verifySignature(
     orderId: string,

--- a/src/modules/payment/payment.controller.ts
+++ b/src/modules/payment/payment.controller.ts
@@ -146,7 +146,6 @@ export class PaymentController {
     };
   }
 
-
   @Get('/wallets')
   @HttpCode(200)
   @Roles([ROLES.PEKERJA, ROLES.PEMBERI_KERJA, ROLES.ADMIN, ROLES.SUPER_ADMIN])

--- a/src/modules/payment/payment.controller.ts
+++ b/src/modules/payment/payment.controller.ts
@@ -146,31 +146,6 @@ export class PaymentController {
     };
   }
 
-  // Not Implement
-  // @Post('/webhook/midtrans')
-  // @HttpCode(200)
-  // @ApiTags('Payment & Wallet', 'Posting Credits')
-  // @ApiOperation({
-  //   summary: 'Midtrans webhook (Wallet & Credit)',
-  //   description: 'Handle Midtrans payment callback for wallet top-up and posting credit purchase (Midtrans only)',
-  // })
-  // @ApiBody({ type: TopupCallbackRequest })
-  // @ApiResponse({
-  //   status: 200,
-  //   description: 'Callback processed',
-  //   schema: {
-  //     type: 'object',
-  //     properties: {
-  //       message: { type: 'string', example: 'OK' },
-  //     },
-  //   },
-  // })
-  // @ApiResponse({ status: 401, description: 'Invalid signature' })
-  // async midtransCallback(@Body() body: TopupCallbackRequest) {
-  //   console.log('Midtrans callback received:', body);
-  //     await this.paymentService.handleCallback(body);
-  //   return { message: 'OK' };
-  // }
 
   @Get('/wallets')
   @HttpCode(200)
@@ -1064,10 +1039,13 @@ export class PaymentController {
 
   @Post('/webhook/midtrans')
   @HttpCode(200)
+  @Throttle({ default: { limit: 100, ttl: 60000 } }) // Override: Midtrans server bisa retry berkali-kali
   @ApiTags('Posting Credits')
   @ApiOperation({
     summary: 'Midtrans credit webhook',
-    description: 'Handle Midtrans credit payment callback (Midtrans only)',
+    description:
+      'Handle Midtrans credit payment callback (Midtrans server-to-server only). ' +
+      'Verifies signature_key before processing. Idempotent — safe to receive duplicate calls.',
   })
   @ApiBody({ type: TopupCallbackRequest })
   @ApiResponse({
@@ -1080,8 +1058,8 @@ export class PaymentController {
       },
     },
   })
+  @ApiResponse({ status: 401, description: 'Invalid signature — request rejected' })
   async midtransCreditCallback(@Body() body: TopupCallbackRequest) {
-    console.log('Midtrans callback received:', body);
     await this.paymentService.handleCallbackCredit(body);
     return { message: 'OK' };
   }

--- a/src/modules/payment/payment.service.ts
+++ b/src/modules/payment/payment.service.ts
@@ -1145,30 +1145,40 @@ export class PaymentService {
   }
 
   async handleCallbackCredit(body: TopupCallbackRequest) {
-    this.logger.info(
-      `[Webhook] Midtrans callback received. order_id=${body.order_id} status=${body.transaction_status}`,
+    // Validasi struktur body terlebih dahulu sebelum memproses apapun
+    const validatedBody = this.validationService.validate(
+      PaymentValidation.MIDTRANS_CALLBACK,
+      body,
     );
 
+    this.logger.info(
+      `[Webhook] Midtrans callback received. order_id=${validatedBody.order_id} status=${validatedBody.transaction_status}`,
+    );
+
+    // Catatan keamanan: JANGAN pernah log signature_key — ini adalah material
+    // kriptografik yang bisa digunakan ulang oleh penyerang.
+    // Hanya log field yang aman seperti order_id, status_code, transaction_status.
+
     const isValid = this.midtransService.verifySignature(
-      body.order_id,
-      body.status_code,
-      body.gross_amount,
-      body.signature_key,
+      validatedBody.order_id,
+      validatedBody.status_code,
+      validatedBody.gross_amount,
+      validatedBody.signature_key,
     );
 
     if (!isValid) {
       this.logger.warn(
-        `[Webhook] Invalid signature for order_id=${body.order_id}. Request rejected.`,
+        `[Webhook] Invalid signature for order_id=${validatedBody.order_id}. Request rejected.`,
       );
       throw new UnauthorizedException('Invalid signature');
     }
 
-    const orderId = body.order_id;
+    const orderId = validatedBody.order_id;
 
-    switch (body.transaction_status) {
+    switch (validatedBody.transaction_status) {
       case 'settlement':
       case 'capture': // kartu kredit Midtrans menggunakan status 'capture'
-        await this.completeTopupCredit(orderId, body);
+        await this.completeTopupCredit(orderId, validatedBody);
         break;
 
       case 'expire':
@@ -1189,7 +1199,7 @@ export class PaymentService {
 
       default:
         this.logger.warn(
-          `[Webhook] Unhandled Midtrans status: ${body.transaction_status} for order_id=${orderId}`,
+          `[Webhook] Unhandled Midtrans status: ${validatedBody.transaction_status} for order_id=${orderId}`,
         );
     }
 

--- a/src/modules/payment/payment.service.ts
+++ b/src/modules/payment/payment.service.ts
@@ -1145,6 +1145,10 @@ export class PaymentService {
   }
 
   async handleCallbackCredit(body: TopupCallbackRequest) {
+    this.logger.info(
+      `[Webhook] Midtrans callback received. order_id=${body.order_id} status=${body.transaction_status}`,
+    );
+
     const isValid = this.midtransService.verifySignature(
       body.order_id,
       body.status_code,
@@ -1153,6 +1157,9 @@ export class PaymentService {
     );
 
     if (!isValid) {
+      this.logger.warn(
+        `[Webhook] Invalid signature for order_id=${body.order_id}. Request rejected.`,
+      );
       throw new UnauthorizedException('Invalid signature');
     }
 
@@ -1160,12 +1167,14 @@ export class PaymentService {
 
     switch (body.transaction_status) {
       case 'settlement':
+      case 'capture': // kartu kredit Midtrans menggunakan status 'capture'
         await this.completeTopupCredit(orderId, body);
         break;
 
       case 'expire':
         await this.markExpired(orderId);
         break;
+
       case 'cancel':
         await this.markFailed(orderId);
         break;
@@ -1175,36 +1184,76 @@ export class PaymentService {
         break;
 
       case 'pending':
+        // Tidak ada aksi — transaksi masih menunggu pembayaran
         break;
 
       default:
-        console.warn('Unhandled Midtrans status:', body.transaction_status);
+        this.logger.warn(
+          `[Webhook] Unhandled Midtrans status: ${body.transaction_status} for order_id=${orderId}`,
+        );
     }
 
+    this.logger.info(
+      `[Webhook] Callback processed successfully. order_id=${orderId}`,
+    );
     return { success: true };
   }
 
   async markExpired(orderId: string) {
-    await this.prismaService.postingCreditPurchase.updateMany({
-      where: {
-        payment_reference: orderId,
-        status: PurchaseStatus.PENDING,
-      },
-      data: {
-        status: PurchaseStatus.EXPIRED,
-      },
+    this.logger.info(`[Webhook] Marking order ${orderId} as EXPIRED`);
+    await this.prismaService.$transaction(async (tx) => {
+      const purchase = await tx.postingCreditPurchase.findUnique({
+        where: { payment_reference: orderId },
+      });
+
+      if (!purchase || purchase.status !== PurchaseStatus.PENDING) return;
+
+      await tx.postingCreditPurchase.updateMany({
+        where: {
+          payment_reference: orderId,
+          status: PurchaseStatus.PENDING,
+        },
+        data: { status: PurchaseStatus.EXPIRED },
+      });
+
+      if (purchase.transaction_id) {
+        await tx.transaction.updateMany({
+          where: {
+            id: purchase.transaction_id,
+            status: TransactonStatus.PENDING,
+          },
+          data: { status: TransactonStatus.FAILED },
+        });
+      }
     });
   }
 
   async markFailed(orderId: string) {
-    await this.prismaService.postingCreditPurchase.updateMany({
-      where: {
-        payment_reference: orderId,
-        status: PurchaseStatus.PENDING,
-      },
-      data: {
-        status: PurchaseStatus.FAILED,
-      },
+    this.logger.info(`[Webhook] Marking order ${orderId} as FAILED`);
+    await this.prismaService.$transaction(async (tx) => {
+      const purchase = await tx.postingCreditPurchase.findUnique({
+        where: { payment_reference: orderId },
+      });
+
+      if (!purchase || purchase.status !== PurchaseStatus.PENDING) return;
+
+      await tx.postingCreditPurchase.updateMany({
+        where: {
+          payment_reference: orderId,
+          status: PurchaseStatus.PENDING,
+        },
+        data: { status: PurchaseStatus.FAILED },
+      });
+
+      if (purchase.transaction_id) {
+        await tx.transaction.updateMany({
+          where: {
+            id: purchase.transaction_id,
+            status: TransactonStatus.PENDING,
+          },
+          data: { status: TransactonStatus.FAILED },
+        });
+      }
     });
   }
 
@@ -1280,7 +1329,7 @@ export class PaymentService {
       },
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     );
-    console.log('Topup success:', orderId);
+    this.logger.info(`[Webhook] Topup credit success for order_id=${orderId}`);
   }
 
   async getPostingCreditPurchaseByUserId(

--- a/src/modules/payment/payment.validation.ts
+++ b/src/modules/payment/payment.validation.ts
@@ -217,4 +217,32 @@ export class PaymentValidation {
       .min(1, 'ID paket kredit minimal 1')
       .positive('ID paket kredit tidak valid'),
   });
+
+  /**
+   * Validasi body webhook dari Midtrans.
+   * Semua field ini wajib ada — jika salah satu kosong,
+   * request akan ditolak sebelum verifikasi signature.
+   * Ref: https://docs.midtrans.com/docs/https-notification-webhooks
+   */
+  static readonly MIDTRANS_CALLBACK = z.object({
+    order_id: z.string({
+      error: () => 'order_id wajib diisi dan harus berupa teks',
+    }).min(1, 'order_id tidak boleh kosong'),
+
+    status_code: z.string({
+      error: () => 'status_code wajib diisi dan harus berupa teks',
+    }).min(1, 'status_code tidak boleh kosong'),
+
+    gross_amount: z.string({
+      error: () => 'gross_amount wajib diisi dan harus berupa teks',
+    }).min(1, 'gross_amount tidak boleh kosong'),
+
+    signature_key: z.string({
+      error: () => 'signature_key wajib diisi dan harus berupa teks',
+    }).min(1, 'signature_key tidak boleh kosong'),
+
+    transaction_status: z.string({
+      error: () => 'transaction_status wajib diisi dan harus berupa teks',
+    }).min(1, 'transaction_status tidak boleh kosong'),
+  });
 }


### PR DESCRIPTION
## Closes #26

## Ringkasan Perubahan

PR ini mengimplementasikan seluruh checklist dari issue #26 — audit & penguatan keamanan payment gateway Midtrans, dengan fokus pada fitur **Top Up Credit** (satu-satunya alur yang aktif di frontend).

---

## Perubahan di payment.controller.ts

- **Hapus dead code**: Blok komentar webhook wallet topup yang tidak pernah dipakai (ex-line ~149-173) dihapus sepenuhnya agar tidak membingungkan
- **Throttle override** pada webhook endpoint diset 100 req/min — agar mekanisme retry dari server Midtrans tidak terkena rate limit
- **Hapus console.log** dari handler webhook
- **Tambah @ApiResponse 401** untuk mendokumentasikan penolakan request jika signature tidak valid

## Perubahan di payment.service.ts

- **Tambah capture status** — kartu kredit Midtrans menggunakan status capture (bukan settlement), keduanya sekarang memanggil completeTopupCredit via fall-through switch-case
- **Ganti semua console.log/warn** dengan 	his.logger (Winston) untuk structured logging
- **Tambah logging** sebelum dan sesudah pemrosesan webhook untuk observability
- **Fix markExpired & markFailed**: Kedua method sekarang juga mengupdate tabel Transaction ke status FAILED di dalam satu DB Transaction — menjaga konsistensi data antar tabel
- **Idempotency guard** di markExpired/markFailed: Skip jika status sudah bukan PENDING, mencegah pemrosesan ulang

---

## Checklist Keamanan

- [x] Signature verification (erifySignature) selalu dieksekusi sebelum memproses callback
- [x] Webhook tidak menggunakan @Auth/@Roles (sudah benar sejak awal)
- [x] Idempotency: completeTopupCredit sudah memiliki guard if (status === PAID) return
- [x] Race condition: updateMany dengan kondisi status: PENDING digunakan sebagai atomic guard
- [x] DB Transaction dengan Serializable isolation level pada completeTopupCredit
- [x] Dead code dihapus